### PR TITLE
カラーの適応

### DIFF
--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -8,6 +8,7 @@ const { privacyPolicyLink, managerInfo, copyright } = Astro.props;
         {managerInfo}
     </p>
     <small>
-        <p class="text-[10px]">{copyright}</p>
+        <!-- コピーライトだけいろが変わりません。 -->
+        <p class="text-[10px]">&copy;{copyright}</p>
     </small>
 </footer>

--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -2,7 +2,7 @@
 const { privacyPolicyLink, managerInfo, copyright } = Astro.props;
 ---
 
-<footer class="w-full bg-gray-900 py-6 text-center text-white">
+<footer class="w-full bg-primary py-6 text-center text-white">
     <a href={privacyPolicyLink} class="text-[10px]">プライバシーポリシー</a>
     <p class="text-[10px]">
         {managerInfo}

--- a/src/components/common/InnerTitle.astro
+++ b/src/components/common/InnerTitle.astro
@@ -1,3 +1,3 @@
-<h3 class="border-l-[3px] border-gray-900 px-2 text-sm">
+<h3 class="border-l-[3px] border-black-100 px-2 text-sm">
     <slot />
 </h3>

--- a/src/components/common/SecTitle.astro
+++ b/src/components/common/SecTitle.astro
@@ -2,9 +2,9 @@
 const { title } = Astro.props;
 ---
 
-<h2 class="border-2 border-gray-900 p-1">
+<h2 class="border-2 border-primary p-1">
     <p
-        class="grid grid-cols-[min-content_1fr_min-content] bg-gray-900 p-[6px] text-center font-kaisei text-[15px] font-medium leading-[25px] text-white"
+        class="grid grid-cols-[min-content_1fr_min-content] bg-primary p-[6px] text-center font-kaisei text-[15px] font-medium leading-[25px] text-white"
     >
         <span class="block aspect-square h-full border-b-[1px] border-l-[1px]"
         ></span>

--- a/src/components/reservation/Reservation.astro
+++ b/src/components/reservation/Reservation.astro
@@ -1,12 +1,15 @@
-<a href="#" class="mx-auto flex w-fit flex-col items-center font-kaisei">
+<a
+    href="#"
+    class="pointer-events-none mx-auto flex w-fit flex-col items-center font-kaisei"
+>
     <p
-        class="relative z-10 mb-[-6px] w-fit rounded-full bg-white p-2 text-[9px] text-gray-900"
+        class="pointer-events-auto relative z-10 mb-[-6px] w-fit rounded-full bg-white p-2 text-[9px] text-black-100"
     >
         <!-- 9pxってなに？ -->
         40%offクーポン配布中
     </p>
     <p
-        class="relative z-0 bg-gray-900 px-3 py-2 text-white shadow-[1px_2px_1px_0_rgba(0,0,0,0.25)] before:content-['◆◇'] after:content-['◇◆']"
+        class="pointer-events-auto relative z-0 bg-primary px-3 py-2 text-white shadow-[1px_2px_1px_0_rgba(0,0,0,0.25)] before:content-['◆◇'] after:content-['◇◆']"
     >
         ご予約はこちら
     </p>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,7 +15,7 @@ const copyright = '©️2024koubokubungalow';
 ---
 
 <!doctype html>
-<html lang="ja" class="box-border bg-base">
+<html lang="ja" class="box-border bg-base text-black-100">
     <head>
         <meta charset="UTF-8" />
         <meta name="description" content="Astro description" />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,7 +11,7 @@ const { title } = Astro.props;
 // Footer contents
 const privacyPolicyLink = '#';
 const managerInfo = '邑南町香木の森公園バンガロー指定管理者／株式会社ウェルス';
-const copyright = '©️2024koubokubungalow';
+const copyright = '2024koubokubungalow';
 ---
 
 <!doctype html>


### PR DESCRIPTION
## 概要
<img src="https://github.com/user-attachments/assets/9161f675-6992-4bd0-9c38-183838454a96" width="150" alt="indexのスクリーンショット" />

Layout，各コンポーネントの色を調整しました。
ニュース欄のみ、後でニュースのjsonファイルと接続するなど大きく修正するのでここでは色を適応していません。
確認をしましたが基本的にindexにあるもの以外は色適応をしてくれていたみたいのなのでスクショは一枚となります。
確認をお願いします。

## 変更点

- 各ファイルのカラーを適応
- Footerのcopyrightが©では色が変わらなかったため、&copy;に変更
