### PR TITLE
幅の調整とmargin-inlineの指定

### DIFF
--- a/src/components/common/SecTitle.astro
+++ b/src/components/common/SecTitle.astro
@@ -2,7 +2,7 @@
 const { title } = Astro.props;
 ---
 
-<h2 class="border-2 border-gray-900 p-1">
+<h2 class="mx-auto w-[250px] border-2 border-gray-900 p-1">
     <p
         class="grid grid-cols-[min-content_1fr_min-content] bg-gray-900 p-[6px] text-center font-kaisei text-[15px] font-medium leading-[25px] text-white"
     >


### PR DESCRIPTION
## 概要
<img src="https://github.com/user-attachments/assets/1a3fc108-7275-4018-871a-19f6eac406af" width="150" alt="secTitleの幅を変更しました。" />

## 変更点

- widthを250pxに変更
- margin-inline:autoをかけて中央寄せにしました。
