### PR TITLE
layoutのpaddingを変更

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -32,7 +32,7 @@ const copyright = '©️2024koubokubungalow';
     </head>
     <body class="font-kurenaido">
         <Header />
-        <main class="px-[14px]">
+        <main class="px-[14px] pt-10">
             <slot />
         </main>
         <Footer

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -16,7 +16,7 @@ import Image04 from '../assets/img04.png';
 
 <Layout title="施設案内">
     <article>
-        <section class="pt-[66px]">
+        <section>
             <SecTitle title="施設案内" />
             <div class="mt-[26px]">
                 <div class="mb-[50px] grid gap-[6px]">

--- a/src/pages/access.astro
+++ b/src/pages/access.astro
@@ -5,7 +5,7 @@ import InnerTitle from '../components/common/InnerTitle.astro';
 ---
 
 <Layout title="アクセス">
-    <article class="pt-[66px]">
+    <article>
         <section>
             <SecTitle title="アクセス" />
             <div class="my-[25px]">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ import Slider from '../components/common/Slider.astro';
 ---
 
 <Layout title="邑南町香木の森公園バンガロー">
-    <section class="pt-10">
+    <section>
         <Image
             src={TopImage}
             alt="バンガローのイメージイラスト"

--- a/src/pages/news.astro
+++ b/src/pages/news.astro
@@ -19,7 +19,7 @@ const regularNews = sortedNews.filter((news) => !news.isImportant);
 ---
 
 <Layout title="お知らせ">
-    <div class="container mx-auto my-6">
+    <div class="container mx-auto mb-6">
         <SecTitle title="お知らせ" />
         {
             // 重要なお知らせが存在する場合表示

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -9,7 +9,7 @@ const { UserPrivacyPolicy, PrivacyItem, Contact } = PrivacyPolicy;
 ---
 
 <Layout title="プライバシーポリシー">
-    <article class="pt-[66px]">
+    <article>
         <section>
             <SecTitle title="プライバシーポリシー" />
 


### PR DESCRIPTION
## 概要
<img width="150" alt="layoutのpaddingを変更" src="https://github.com/user-attachments/assets/fc0f1908-27b5-4993-a215-1609050754d5" />

indexはヘッダーとベタ付けで、他の要素はあとからパンくずリストが入ることを考えるとこの余白が適正かと思います。
確認お願いします。

## 変更点

- layoutのmainタグにpadding-topを指定
- newsページのpy-6をpb-6へ変更