### PR TITLE
Style/header responsive

### DIFF
--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -11,7 +11,7 @@ const navItems = [
 
 <header
     id="header"
-    class="fixed left-0 top-0 z-50 h-fit w-full bg-[#FAF7F0] px-6"
+    class="fixed left-1/2 top-0 z-50 h-fit w-full max-w-5xl -translate-x-1/2 bg-[#FAF7F0] px-6"
 >
     <nav class="grid">
         <!-- メニューボタン -->

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -60,7 +60,7 @@ const navItems = [
 
     menuButton?.addEventListener('click', () => {
         menuList?.classList.toggle('h-fit');
-        menuBg?.classList.toggle('pointer-events-auto');
-        menuBg?.classList.toggle('backdrop-blur-sm');
+        menuBg?.classList.toggle('lg:pointer-events-auto');
+        menuBg?.classList.toggle('lg:backdrop-blur-sm');
     });
 </script>

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -51,7 +51,11 @@ const navItems = [
     </nav>
 </header>
 <!-- 背景 -->
-<div id="bg" class="pointer-events-none fixed inset-0 z-20"></div>
+<div
+    id="bg"
+    class="pointer-events-none fixed inset-0 z-20 lg:pointer-events-none lg:backdrop-blur-none"
+>
+</div>
 
 <script>
     const menuButton = document.getElementById('menuButton');
@@ -60,7 +64,7 @@ const navItems = [
 
     menuButton?.addEventListener('click', () => {
         menuList?.classList.toggle('h-fit');
-        menuBg?.classList.toggle('lg:pointer-events-auto');
-        menuBg?.classList.toggle('lg:backdrop-blur-sm');
+        menuBg?.classList.toggle('pointer-events-auto');
+        menuBg?.classList.toggle('backdrop-blur-sm');
     });
 </script>

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -5,7 +5,7 @@ const navItems = [
     { name: '施設案内', link: '/about/' },
     { name: 'ご予約について', link: '/reservation/' },
     { name: 'アクセス', link: '/access/' },
-    { name: 'ご意見・ご感想・お問い合わせ', link: '/contact/' },
+    { name: 'お問い合わせ', link: '/contact/' },
 ];
 ---
 
@@ -36,12 +36,12 @@ const navItems = [
         <!-- ナビゲーションリスト -->
         <ul
             id="menuList"
-            class="h-0 overflow-hidden bg-base text-center duration-200 lg:h-fit lg:overflow-visible"
+            class="h-0 overflow-hidden bg-base text-center duration-200 lg:grid lg:h-fit lg:grid-cols-6 lg:overflow-visible"
         >
             {
                 navItems.map((item) => (
-                    <li class="border-b border-gray-900 last:border-none">
-                        <a href={item.link} class="block py-3">
+                    <li class="border-b border-gray-900 last:border-none lg:border-none">
+                        <a href={item.link} class="block py-3 font-kaisei">
                             {item.name}
                         </a>
                     </li>
@@ -50,12 +50,17 @@ const navItems = [
         </ul>
     </nav>
 </header>
+<!-- 背景 -->
+<div id="bg" class="pointer-events-none fixed inset-0 z-20"></div>
 
 <script>
     const menuButton = document.getElementById('menuButton');
     const menuList = document.getElementById('menuList');
+    const menuBg = document.getElementById('bg');
 
     menuButton?.addEventListener('click', () => {
         menuList?.classList.toggle('h-fit');
+        menuBg?.classList.toggle('pointer-events-auto');
+        menuBg?.classList.toggle('backdrop-blur-sm');
     });
 </script>

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -11,20 +11,33 @@ const navItems = [
 
 <header
     id="header"
-    class="fixed left-0 top-0 h-fit w-full bg-[#FAF7F0] px-6 z-50"
+    class="fixed left-0 top-0 z-50 h-fit w-full bg-[#FAF7F0] px-6"
 >
     <nav class="grid">
         <!-- メニューボタン -->
         <button
             id="menuButton"
-            class="ml-auto h-10 w-10 flex justify-center items-center"
+            class="ml-auto flex h-10 w-10 items-center justify-center lg:hidden"
             aria-expanded="false"
-            aria-label="Toggle Menu">
-            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#4A4947"><path d="M120-240v-80h720v80H120Zm0-200v-80h720v80H120Zm0-200v-80h720v80H120Z"/></svg>
+            aria-label="Toggle Menu"
+        >
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                height="24px"
+                viewBox="0 -960 960 960"
+                width="24px"
+                fill="#4A4947"
+                ><path
+                    d="M120-240v-80h720v80H120Zm0-200v-80h720v80H120Zm0-200v-80h720v80H120Z"
+                ></path></svg
+            >
         </button>
 
         <!-- ナビゲーションリスト -->
-        <ul id="menuList" class="h-0 overflow-hidden text-center duration-200">
+        <ul
+            id="menuList"
+            class="h-0 overflow-hidden bg-base text-center duration-200 lg:h-fit lg:overflow-visible"
+        >
             {
                 navItems.map((item) => (
                     <li class="border-b border-gray-900 last:border-none">

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -67,4 +67,10 @@ const navItems = [
         menuBg?.classList.toggle('pointer-events-auto');
         menuBg?.classList.toggle('backdrop-blur-sm');
     });
+
+    menuBg?.addEventListener('click', () => {
+        menuList?.classList.toggle('h-fit');
+        menuBg?.classList.toggle('pointer-events-auto');
+        menuBg?.classList.toggle('backdrop-blur-sm');
+    });
 </script>


### PR DESCRIPTION
## 概要

<img width="1403" alt="image" src="https://github.com/user-attachments/assets/23c99570-ba42-4855-aa5b-fdc85cdba704">
<img width="435" alt="image" src="https://github.com/user-attachments/assets/34a39eb4-daa4-4bb9-b063-22e9efce6aaf">

## 変更点

- PC用のレイアウトを表示するよう変更
- SMのメニューを開いた際にそれ以外を触った際は閉じるよう変更
- メニュー展開時にブラーを設定（必要なければ消します）

PC用のものを作ったら少しヘッダーが大きくなってコンテンツが切れてしまうので、そこは改めて調整する必要がありそう。
一通り終わったらLayoutをいじる感じでいいと思う。

## 関連Issue

close #37 
