### PR TITLE
お知らせページにNoticeBoxを追加

### DIFF
--- a/src/components/news/CouponItem.astro
+++ b/src/components/news/CouponItem.astro
@@ -1,6 +1,7 @@
 ---
 import InnerTitle from '../common/InnerTitle.astro';
 import Button from '../ui/Button.astro';
+import NoticeBox from '../ui/NoticeBox.astro';
 
 const { title, content, date } = Astro.props;
 ---
@@ -20,7 +21,14 @@ const { title, content, date } = Astro.props;
         <div class="">
             <Button buttonText="クーポンをGET!" />
         </div>
-        <!-- TODO: NotesBoxコンポーネントを今後追加 -->
+        <NoticeBox
+            items={[
+                "予約可能期間は2022.06.04.19:59までです。",
+                "宿泊可能期間は2022.07.01チェックアウトです。",
+                "先着20枚となります。",
+                "土日曜日の宿泊にはご利用いただけません。",
+            ]}
+        />
     </div>
     <div class="flex items-center space-x-3">
         <div class="h-[0px] w-full border-[0.5px] border-black-100 opacity-30">


### PR DESCRIPTION
## 概要
<img width="544" alt="image" src="https://github.com/user-attachments/assets/11290435-95e9-449c-aef7-90b4f72f375a">

NoticeBoxを追加したけれど、Figmaの方では `※` 表記になっててどうしたものか。。。

## 関連Issue
closed #41
