### PR TITLE
パンくずリストを追加

### DIFF
--- a/src/components/common/BreadCrumb.astro
+++ b/src/components/common/BreadCrumb.astro
@@ -1,0 +1,30 @@
+---
+
+interface BreadcrumbItem {
+    name: string;
+    link?: string | null;
+}
+
+interface Props {
+    items: BreadcrumbItem[];
+}
+
+const { items } = Astro.props;
+---
+
+<nav aria-label="breadcrumb" class="px-4 py-2 bg-accent mb-8">
+    <ol class="flex text-sm font-kaisei">
+        {items.map((item, index) => (
+            <li class="flex items-center">
+                {index > 0 && <span class="mx-2">></span>}
+                {item.link ? (
+                    <a href={item.link} class="hover:underline">
+                        {item.name}
+                    </a>
+                ) : (
+                    <span class="text-gray-500">{item.name}</span>
+                )}
+            </li>
+        ))}
+    </ol>
+</nav>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,12 +1,20 @@
 ---
+import BreadCrumb from '../components/common/BreadCrumb.astro';
 import Footer from '../components/common/Footer.astro';
 import Header from '../components/common/Header.astro';
 
-interface Props {
-    title: string;
+interface BreadcrumbItem {
+    name: string;
+    link?: string | null;
 }
 
-const { title } = Astro.props;
+interface Props {
+    title: string;
+    breadcrumbItems?: BreadcrumbItem[];
+}
+
+const { title, breadcrumbItems } = Astro.props;
+const currentPath = Astro.url.pathname; // 現在のパスを取得
 
 // Footer contents
 const privacyPolicyLink = '/privacy/';
@@ -35,6 +43,9 @@ const copyright = '2024koubokubungalow';
         <Header />
         <!-- TODO: パンくずリストコンポーネントをここに追加 "/index" のみを非表示に -->
         <main class="px-6 py-10 lg:py-12">
+            {currentPath !== '/' && breadcrumbItems && (
+                <BreadCrumb items={breadcrumbItems} />
+            )}
             <slot />
         </main>
         <Footer

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -12,9 +12,14 @@ import About05 from '../assets/about/about05.png';
 import About06 from '../assets/about/about06.png';
 import About07 from '../assets/about/about07.png';
 import Image04 from '../assets/img04.png';
+
+const breadcrumbItems = [
+    { name: 'ホーム', link: '/' },
+    { name: '施設案内', link: '/about' },
+];
 ---
 
-<Layout title="施設案内">
+<Layout title="施設案内" breadcrumbItems={breadcrumbItems}>
     <article>
         <section>
             <SecTitle title="施設案内" />

--- a/src/pages/access.astro
+++ b/src/pages/access.astro
@@ -2,9 +2,14 @@
 import Layout from '../layouts/Layout.astro';
 import SecTitle from '../components/common/SecTitle.astro';
 import InnerTitle from '../components/common/InnerTitle.astro';
+
+const breadcrumbItems = [
+    { name: 'ホーム', link: '/' },
+    { name: 'アクセス', link: '/access' },
+];
 ---
 
-<Layout title="アクセス">
+<Layout title="アクセス" breadcrumbItems={breadcrumbItems}>
     <article>
         <section>
             <SecTitle title="アクセス" />

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -4,9 +4,14 @@ import SecTitle from '../components/common/SecTitle.astro';
 import { Image } from 'astro:assets';
 import Image05 from '../assets/img05.png';
 import InnerTitle from '../components/common/InnerTitle.astro';
+
+const breadcrumbItems = [
+    { name: 'ホーム', link: '/' },
+    { name: 'お問い合わせ', link: '/contact' },
+];
 ---
 
-<Layout title="お問い合わせ">
+<Layout title="お問い合わせ" breadcrumbItems={breadcrumbItems}>
     <section>
         <SecTitle title="お問い合わせ" />
         <form class="grid gap-4 py-6 lg:grid-cols-2">

--- a/src/pages/news.astro
+++ b/src/pages/news.astro
@@ -16,9 +16,14 @@ const sortedNews = newsData.news.sort(
 // 重要なお知らせ（isImportant が true）のアイテムを抽出
 const importantNews = sortedNews.filter((news) => news.isImportant);
 const regularNews = sortedNews.filter((news) => !news.isImportant);
+
+const breadcrumbItems = [
+    { name: 'ホーム', link: '/' },
+    { name: 'お知らせ', link: '/news' },
+];
 ---
 
-<Layout title="お知らせ">
+<Layout title="お知らせ" breadcrumbItems={breadcrumbItems}>
     <div class="mb-6">
         <SecTitle title="お知らせ" />
         {

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -6,9 +6,14 @@ import PrivacyBox from '../components/privacy/PrivacyBox.astro';
 import PrivacyPolicy from '../locales/ja/PrivacyPolicy.json';
 
 const { UserPrivacyPolicy, PrivacyItem, Contact } = PrivacyPolicy;
+
+const breadcrumbItems = [
+    { name: 'ホーム', link: '/' },
+    { name: 'プライバシーポリシー', link: '/privacy' },
+];
 ---
 
-<Layout title="プライバシーポリシー">
+<Layout title="プライバシーポリシー" breadcrumbItems={breadcrumbItems}>
     <article>
         <section>
             <SecTitle title="プライバシーポリシー" />

--- a/src/pages/reservation.astro
+++ b/src/pages/reservation.astro
@@ -9,9 +9,14 @@ import { Image } from 'astro:assets';
 import Reservation01 from '../assets/img05.png';
 import Reservation02 from '../assets/img01.png';
 import NoticeBox from '../components/ui/NoticeBox.astro';
+
+const breadcrumbItems = [
+    { name: 'ホーム', link: '/' },
+    { name: 'ご予約について', link: '/reservation' },
+];
 ---
 
-<Layout title="ご予約について">
+<Layout title="ご予約について" breadcrumbItems={breadcrumbItems}>
     <!-- ご予約について -->
     <section>
         <SecTitle title="ご予約について" />


### PR DESCRIPTION
## 概要
<img width="547" alt="image" src="https://github.com/user-attachments/assets/07baa53c-da6e-4372-b7d3-6fdabce201b0">

## 変更点
- BreadcrumbItemコンポーネントを作成
- `/` のみ非表示に設定
- 各ページでパンくずをカスタマイズできるように（めんどくさいかも。。。

## 関連Issue
closed #38
